### PR TITLE
Use unencrypted state

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -136,7 +136,7 @@ if ( ["localhost", "127.0.0.1", ""].includes(window.location.hostname) ) {
   snapId = 'local:http://localhost:8080';
 }
 else { 
-  snapVersion = '^0.2.0'; 
+  snapVersion = '^0.3.0'; 
 }
 
 const isFlask = async () => {

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pet-fox",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Everyone wants a pet fox",
   "repository": {
     "type": "git",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Everyone wants a pet fox.",
   "proposedName": "Pet Fox",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/Montoya/pet-fox.git"
   },
   "source": {
-    "shasum": "IVrWOt9c6cnWSTWe36W27VeTeNuvN+PAHwhrXD66blA=",
+    "shasum": "nskH3vV2a7I6tiyzyTAzWxxdAV+Ipe/d/TGlFWNc2vM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -113,14 +113,14 @@ const foxSave = async function(fox:typeof Fox) {
   let state = { petFox: fox }; 
   await snap.request({ 
     method: 'snap_manageState', 
-    params: { operation: 'update', newState: state }, 
+    params: { operation: 'update', newState: state, encrypted: false }, 
   }); 
 }
 
 const foxCheck = async function() { 
   let state = (await snap.request({
     method: 'snap_manageState',
-    params: { operation: 'get' },
+    params: { operation: 'get', encrypted: false },
   }));
   if(state) { return true; }
   return false; 
@@ -129,7 +129,7 @@ const foxCheck = async function() {
 const foxCall = async function() { 
   let state = (await snap.request({
     method: 'snap_manageState',
-    params: { operation: 'get' },
+    params: { operation: 'get', encrypted: false },
   }));
 
   if (!state) {
@@ -137,7 +137,7 @@ const foxCall = async function() {
     // initialize state if empty and set default data
     await snap.request({
       method: 'snap_manageState',
-      params: { operation: 'update', newState: state },
+      params: { operation: 'update', newState: state, encrypted: false },
     });
   }
 


### PR DESCRIPTION
Encrypted state is not compatible with cron jobs because it will fail to read / write when MetaMask is locked. This changes the logic of the Snap to always use unencrypted state.